### PR TITLE
feat: make pools cluster scoped

### DIFF
--- a/api/v1alpha1/pool_types.go
+++ b/api/v1alpha1/pool_types.go
@@ -30,6 +30,7 @@ type PoolStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:path=pools,scope=Cluster
 
 // Pool is the Schema for the pools API
 // See https://book.kubebuilder.io/reference/markers/crd.html

--- a/hack/config/crd/upgrade.talos.dev_pools.yaml
+++ b/hack/config/crd/upgrade.talos.dev_pools.yaml
@@ -36,7 +36,7 @@ spec:
     listKind: PoolList
     plural: pools
     singular: pool
-  scope: Namespaced
+  scope: Cluster
   subresources: {}
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
It doesn't make sense to have namespaced pools. This changes pools to be
cluster scoped.