### PR TITLE
chore: fetch git tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,6 +18,11 @@ services:
         path: /var/run
 
 steps:
+  - name: git-fetch-tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+
   - name: build-pull-request
     image: autonomy/build-container:latest
     pull: always


### PR DESCRIPTION
We need to fetch git tags in order for our image tagging to work
correctly.