### PR TITLE
refactor: remove name from spec

### DIFF
--- a/api/v1alpha1/pool_types.go
+++ b/api/v1alpha1/pool_types.go
@@ -12,7 +12,6 @@ import (
 
 // PoolSpec defines the desired state of Pool
 type PoolSpec struct {
-	Name          string           `json:"name,omitempty"`
 	Channel       string           `json:"channel,omitempty"`
 	Version       string           `json:"version,omitempty"`
 	Registry      string           `json:"registry,omitempty"`

--- a/hack/config/crd/upgrade.talos.dev_pools.yaml
+++ b/hack/config/crd/upgrade.talos.dev_pools.yaml
@@ -63,8 +63,6 @@ spec:
               type: string
             concurrency:
               type: integer
-            name:
-              type: string
             onFailure:
               type: string
             registry:

--- a/hack/config/examples/pools.yaml
+++ b/hack/config/examples/pools.yaml
@@ -1,10 +1,9 @@
 apiVersion: upgrade.talos.dev/v1alpha1
 kind: Pool
 metadata:
-  name: control-plane-example
+  name: serial-latest
   namespace: talos-system
 spec:
-  name: serial-latest
   channel: latest
   registry: https://registry-1.docker.io
   repository: autonomy/installer
@@ -15,10 +14,9 @@ spec:
 apiVersion: upgrade.talos.dev/v1alpha1
 kind: Pool
 metadata:
-  name: workers-example
+  name: concurrent-latest
   namespace: talos-system
 spec:
-  name: concurrent-latest
   channel: latest
   registry: https://registry-1.docker.io
   repository: autonomy/installer

--- a/pkg/controllers/pool_controller.go
+++ b/pkg/controllers/pool_controller.go
@@ -71,7 +71,7 @@ func (r *PoolReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	if pool.Status.NextRun.Time.After(time.Now()) {
-		r.Log.Info("skipping reconciliation, next run is in the future", "pool", pool.Spec.Name)
+		r.Log.Info("skipping reconciliation, next run is in the future", "pool", pool.Name)
 		return ctrl.Result{RequeueAfter: pool.Spec.CheckInterval.Duration}, nil
 	}
 
@@ -106,7 +106,7 @@ func (r *PoolReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			return r.Result(ctx, req, false), fmt.Errorf("no version found for %q channel", pool.Spec.Channel)
 		}
 
-		r.Log.Info("obtained version for pool", "version", v, "pool", pool.Spec.Name, "channel", pool.Spec.Channel)
+		r.Log.Info("obtained version for pool", "version", v, "pool", pool.Name, "channel", pool.Spec.Channel)
 	}
 
 	c := &upgrader.Context{
@@ -121,7 +121,7 @@ func (r *PoolReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		Concurrency: pool.Spec.Concurrency,
 	}
 
-	label, err := labels.NewRequirement(constants.V1Alpha1PoolLabel, selection.Equals, []string{pool.Spec.Name})
+	label, err := labels.NewRequirement(constants.V1Alpha1PoolLabel, selection.Equals, []string{pool.Name})
 	if err != nil {
 		return r.Result(ctx, req, false), err
 	}
@@ -158,7 +158,7 @@ func (r *PoolReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	if len(nodesInProgess.Items) > 0 {
-		r.Log.Info("pool has upgrades in progress", "count", len(nodesInProgess.Items), "pool", pool.Spec.Name, "channel", pool.Spec.Channel)
+		r.Log.Info("pool has upgrades in progress", "count", len(nodesInProgess.Items), "pool", pool.Name, "channel", pool.Spec.Channel)
 		if err := policy.Run(nodesInProgess, v); err != nil {
 			r.Log.Error(err, "upgrade failed")
 		}
@@ -192,7 +192,7 @@ func (r *PoolReconciler) Result(ctx context.Context, req ctrl.Request, fail bool
 
 	defer func() {
 		if err := r.Update(ctx, &pool); err != nil {
-			r.Log.Info("failed to update pool", "pool", pool.Spec.Name)
+			r.Log.Info("failed to update pool", "pool", pool.Name)
 		}
 	}()
 
@@ -201,7 +201,7 @@ func (r *PoolReconciler) Result(ctx context.Context, req ctrl.Request, fail bool
 		case "Pause":
 			pool.Status.NextRun = metav1.Time{}
 
-			r.Log.Info("pausing upgrades", "pool", pool.Spec.Name)
+			r.Log.Info("pausing upgrades", "pool", pool.Name)
 
 			return ctrl.Result{Requeue: false}
 		case "Retry":
@@ -211,7 +211,7 @@ func (r *PoolReconciler) Result(ctx context.Context, req ctrl.Request, fail bool
 
 	pool.Status.NextRun = next
 
-	r.Log.Info("requeuing upgrade", "when", next.Time, "pool", pool.Spec.Name)
+	r.Log.Info("requeuing upgrade", "when", next.Time, "pool", pool.Name)
 
 	return ctrl.Result{RequeueAfter: pool.Spec.CheckInterval.Duration}
 }


### PR DESCRIPTION
The name in the spec is redundant. We can key off of the name of the
pool instead.