### PR TITLE
fix: always set pool version status

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ steps:
         from_secret: kubeconfig
     privileged: true
     volumes:
-      - name: dockersock
+      - name: docker-socket
         path: /var/run
       - name: docker
         path: /root/.docker/buildx
@@ -56,7 +56,7 @@ steps:
         include:
           - pull_request
     volumes:
-      - name: dockersock
+      - name: docker-socket
         path: /var/run
       - name: docker
         path: /root/.docker/buildx
@@ -79,7 +79,7 @@ steps:
         exclude:
           - pull_request
     volumes:
-      - name: dockersock
+      - name: docker-socket
         path: /var/run
       - name: docker
         path: /root/.docker/buildx
@@ -95,7 +95,7 @@ steps:
       event:
         - tag
     volumes:
-      - name: dockersock
+      - name: docker-socket
         path: /var/run
       - name: docker
         path: /root/.docker/buildx

--- a/pkg/controllers/pool_controller.go
+++ b/pkg/controllers/pool_controller.go
@@ -114,7 +114,9 @@ func (r *PoolReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 
 		r.Log.Info("obtained version for pool", "version", v, "pool", pool.Name, "channel", pool.Spec.Channel)
+	}
 
+	if pool.Status.Version != v {
 		pool.Status.Version = v
 
 		if err := r.Update(context.TODO(), &pool); err != nil {


### PR DESCRIPTION
The pool version status needs to be updated even when using and
explicit version instead of a channel. This ensures that and also
conditionally performs a status update.