### PR TITLE
refactor: update status on every reconcile

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,7 +151,6 @@ func main() {
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")
-	// if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 	if err := run(mgr, "talos-controller-manager", "talos-system"); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)


### PR DESCRIPTION
This changes the order of operations to ensure that the pool's status is
up to date even if the next check is in the future.