### PR TITLE
feat: allow 10 concurrent reconciles

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	// +kubebuilder:scaffold:imports
@@ -144,7 +145,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("Pool"),
 		Upgrader: u,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: 10}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pool")
 		os.Exit(1)
 	}

--- a/pkg/controllers/pool_controller.go
+++ b/pkg/controllers/pool_controller.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	poolv1alpha1 "github.com/talos-systems/talos-controller-manager/api/v1alpha1"
 	"github.com/talos-systems/talos-controller-manager/pkg/channel"
@@ -47,8 +48,9 @@ func (r *PoolReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcile(ctx, req, log)
 }
 
-func (r *PoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *PoolReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&poolv1alpha1.Pool{}).
 		Complete(r)
 }


### PR DESCRIPTION
This allows for more than one reconcile to run at time. This
translates into multiple pools being upgraded at once if their scheduled
runs overlap.