### PR TITLE
feat: remove the need for node annotations

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -10,8 +10,6 @@ const (
 	DefaultRepository = "docker.io/autonomy/installer"
 
 	InstallerVersionLabel = "alpha.talos.dev/version"
-
-	InProgressAnnotation = "v1alpha1.upgrade.talos.dev/inprogress"
 )
 
 // Pool labels

--- a/pkg/controllers/pool_controller.go
+++ b/pkg/controllers/pool_controller.go
@@ -174,7 +174,7 @@ func (r *PoolReconciler) reconcile(ctx context.Context, req ctrl.Request, log lo
 	policy := upgrader.NewConcurrentPolicy(r.Upgrader, pool.Spec.Concurrency)
 
 	if len(nodesInProgess.Items) > 0 {
-		if err := policy.Run(req, nodesInProgess, v); err != nil {
+		if err := policy.Run(req, nodesInProgess, v, true); err != nil {
 			log.Error(err, "upgrade failed")
 
 			return r.Result(ctx, req, true, log), err
@@ -183,7 +183,7 @@ func (r *PoolReconciler) reconcile(ctx context.Context, req ctrl.Request, log lo
 
 	// Upgrade all nodes.
 
-	if err := policy.Run(req, nodes, v); err != nil {
+	if err := policy.Run(req, nodes, v, false); err != nil {
 		log.Error(err, "upgrade failed")
 
 		return r.Result(ctx, req, true, log), err

--- a/pkg/upgrader/upgrade_policy_serial.go
+++ b/pkg/upgrader/upgrade_policy_serial.go
@@ -13,9 +13,9 @@ type SerialPolicy struct {
 	Upgrader
 }
 
-func (policy SerialPolicy) Run(req reconcile.Request, nodes corev1.NodeList, version string) error {
+func (policy SerialPolicy) Run(req reconcile.Request, nodes corev1.NodeList, version string, inProgress bool) error {
 	for _, node := range nodes.Items {
-		if err := policy.Upgrade(req, node, version); err != nil {
+		if err := policy.Upgrade(req, node, version, inProgress); err != nil {
 			return err
 		}
 	}

--- a/pkg/upgrader/upgrader_interface.go
+++ b/pkg/upgrader/upgrader_interface.go
@@ -10,5 +10,5 @@ import (
 )
 
 type Upgrader interface {
-	Upgrade(reconcile.Request, corev1.Node, string) error
+	Upgrade(reconcile.Request, corev1.Node, string, bool) error
 }


### PR DESCRIPTION
This removes the dependency on node annotations to figure out if a node
upgrade is current in progress. The "in progress" data is currently
storred in the CRD's status, and as an annotation on the node. In the
case that a user needs to override the in progress status for whatever
reason, they currently need to modify the CRD and the node. To keep
things simple, we now only use the CRD for node's "in progress" status.