### PR TITLE
hardcode ghcr instead of docker

### DIFF
--- a/pkg/upgrader/upgrader_v1alpha1.go
+++ b/pkg/upgrader/upgrader_v1alpha1.go
@@ -131,7 +131,7 @@ func (v1alpha1 V1Alpha1) Upgrade(req reconcile.Request, node corev1.Node, tag st
 	}
 
 	// TODO(andrewrynhard): This should be passed in.
-	image := fmt.Sprintf("docker.io/%s:%s", pool.Spec.Repository, tag)
+	image := fmt.Sprintf("ghcr.io/%s:%s", pool.Spec.Repository, tag)
 
 	// TODO(andrewrynhard): Ensure that we have found the internal address.
 	var target string


### PR DESCRIPTION
Talos moves from docker.io to ghcr.io a while back, but the controller manager still has a hardcoded reference to docker. With this trivial patch ghcr is hardcoded. Someone should probably make it configurable, but at least it works with recent Talos now. Fixes the symptoms of #43.